### PR TITLE
Keep permissions compatible with Plone versions

### DIFF
--- a/src/collective/polls/portlet/configure.zcml
+++ b/src/collective/polls/portlet/configure.zcml
@@ -1,10 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="collective.polls">
 
      <!-- Register the portlet -->
+
+     <include package="Products.CMFCore" zcml:condition="have plone-41" file="permissions.zcml" />
 
      <plone:portlet
          name="collective.polls.VotePortlet"


### PR DESCRIPTION
Only if use the "cmf.ManagePortal" or CMF permissions.

The startup code of Zope (application server which Plone is based on) has changed to some degree in Zope 2.13 and there might be some code that no longer works - if it depended on specific import time and ZCML configuration ordering. In Plone 4 you generally need to be more explicit about your ZCML dependencies. If you use the the cmf.ManagePortal permission, you can either do an <include package="Products.CMFCore"file="permissions.zcml" /> (which works in Plone 4.0.x as well) or do a  general include of Products.CMFPlone at the start of your configure.zcml.
