### PR TITLE
Fix HTTP caching headers on update-poll browser view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ There's a frood who really knows where his towel is.
 - Update i18n, Brazilian Portuguese and Spanish translations.
   [hvelarde]
 
+- Fix HTTP caching headers on ``update-poll`` browser view (fixes `#117 <https://github.com/collective/collective.polls/issues/117>`_);
+  a poll now updates its modification date on every vote.
+  [hvelarde]
+
 - Upgrade steps 2, 3 and 4 were removed.
   [hvelarde]
 

--- a/src/collective/polls/browser/update_poll.py
+++ b/src/collective/polls/browser/update_poll.py
@@ -4,14 +4,38 @@ from Products.Five.browser import BrowserView
 
 
 class UpdatePollView(PollsViewMixin, BrowserView):
-
-    """View to update poll results"""
+    """View to show poll results."""
 
     def poll(self):
         return self.context
 
+    def is_safe_method(self):
+        """Check if the request was made using a safe method."""
+        safe_methods = ('GET', 'HEAD')
+        return self.request.get('REQUEST_METHOD', 'GET').upper() in safe_methods
+
     def __call__(self):
-        # avoid issues with reverse proxies:
-        # define response as non-cacheable and require revalidation
-        self.request.response.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        """Render the results of a poll.
+
+        Make use of HTTP caching headers to decrease server usage:
+        results are cached 120 seconds on browsers and 60 seconds on
+        intermediate caches. We use the last modified date as ETag to
+        return a 304 (Not Modified) status in case the poll has not
+        being modified since last time it was accessed.
+
+        More information: https://httpwg.org/specs/rfc7234.html
+        """
+        if not self.is_safe_method():
+            self.request.response.setStatus(412)  # Precondition Failed
+            return ''
+
+        modified = str(self.context.modified().timeTime())
+        self.request.response.setHeader('Cache-Control', 'max-age=120, s-maxage=60')
+        self.request.response.setHeader('ETag', modified)
+
+        match = self.request.get_header('If-None-Match', '')
+        if modified == match:
+            self.request.response.setStatus(304)  # Not Modified
+            return ''
+
         return super(UpdatePollView, self).__call__()

--- a/src/collective/polls/browser/update_poll.py
+++ b/src/collective/polls/browser/update_poll.py
@@ -18,9 +18,9 @@ class UpdatePollView(PollsViewMixin, BrowserView):
         """Render the results of a poll.
 
         Make use of HTTP caching headers to decrease server usage:
-        results are cached 120 seconds on browsers and 60 seconds on
-        intermediate caches. We use the last modified date as ETag to
-        return a 304 (Not Modified) status in case the poll has not
+        results are not cached on browsers and are cached 120 seconds
+        on intermediate caches. We use the last modified date as ETag
+        to return a 304 (Not Modified) status in case the poll has not
         being modified since last time it was accessed.
 
         More information: https://httpwg.org/specs/rfc7234.html
@@ -30,7 +30,7 @@ class UpdatePollView(PollsViewMixin, BrowserView):
             return ''
 
         modified = str(self.context.modified().timeTime())
-        self.request.response.setHeader('Cache-Control', 'max-age=120, s-maxage=60')
+        self.request.response.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
         self.request.response.setHeader('ETag', modified)
 
         match = self.request.get_header('If-None-Match', '')

--- a/src/collective/polls/content/poll.py
+++ b/src/collective/polls/content/poll.py
@@ -17,9 +17,11 @@ from plone.supermodel import model
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.component import queryUtility
+from zope.event import notify
 from zope.interface import implementer
 from zope.interface import Invalid
 from zope.interface import invariant
+from zope.lifecycleevent import ObjectModifiedEvent
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
@@ -204,6 +206,7 @@ class Poll(Item):
             vote_key = VOTE_ANNO_KEY % option  # noqa: S001
             votes = annotations.get(vote_key, 0)
             annotations[vote_key] = votes + 1
+        notify(ObjectModifiedEvent(self))
         return True
 
 

--- a/src/collective/polls/tests/test_content.py
+++ b/src/collective/polls/tests/test_content.py
@@ -343,3 +343,17 @@ class VotingTest(unittest.TestCase):
         self.assertEqual(results[options][1], 1)
         # 50%
         self.assertEqual(results[options][2], 0.5)
+
+    def test_modification_time(self):
+        poll = self.p3
+        logout()
+
+        # a vote must modify the poll
+        last_modified = poll.modified()
+        poll.setVote(0, self.request)
+        self. assertGreater(poll.modified(), last_modified)
+
+        # another vote also modifies the poll
+        last_modified = poll.modified()
+        poll.setVote(0, self.request)
+        self. assertGreater(poll.modified(), last_modified)

--- a/src/collective/polls/tests/test_views.py
+++ b/src/collective/polls/tests/test_views.py
@@ -29,7 +29,7 @@ class UpdatePollViewTestCase(ViewTestCase):
 
         headers = self.request.response.headers
         self.assertEqual(self.request.response.getStatus(), 200)
-        self.assertEqual(headers['cache-control'], 'max-age=120, s-maxage=60')
+        self.assertEqual(headers['cache-control'], 'max-age=0, s-maxage=120')
         self.assertEqual(headers['etag'], last_modified)
 
     def test_headers_match(self):
@@ -39,7 +39,7 @@ class UpdatePollViewTestCase(ViewTestCase):
 
         headers = self.request.response.headers
         self.assertEqual(self.request.response.getStatus(), 304)
-        self.assertEqual(headers['cache-control'], 'max-age=120, s-maxage=60')
+        self.assertEqual(headers['cache-control'], 'max-age=0, s-maxage=120')
         self.assertEqual(headers['etag'], last_modified)
 
     def test_non_safe_method(self):

--- a/src/collective/polls/tests/test_views.py
+++ b/src/collective/polls/tests/test_views.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from collective.polls.testing import INTEGRATION_TESTING
+from plone import api
+
+import unittest
+
+
+class ViewTestCase(unittest.TestCase):
+
+    layer = INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        with api.env.adopt_roles(['Manager']):
+            self.poll = api.content.create(
+                self.portal, 'collective.polls.poll', 'poll')
+
+
+class UpdatePollViewTestCase(ViewTestCase):
+
+    def render(self):
+        view = api.content.get_view('update-poll', self.poll, self.request)
+        view()
+
+    def test_headers_no_match(self):
+        last_modified = str(self.poll.modified().timeTime())
+        self.render()
+
+        headers = self.request.response.headers
+        self.assertEqual(self.request.response.getStatus(), 200)
+        self.assertEqual(headers['cache-control'], 'max-age=120, s-maxage=60')
+        self.assertEqual(headers['etag'], last_modified)
+
+    def test_headers_match(self):
+        last_modified = str(self.poll.modified().timeTime())
+        self.request.environ['IF_NONE_MATCH'] = last_modified
+        self.render()
+
+        headers = self.request.response.headers
+        self.assertEqual(self.request.response.getStatus(), 304)
+        self.assertEqual(headers['cache-control'], 'max-age=120, s-maxage=60')
+        self.assertEqual(headers['etag'], last_modified)
+
+    def test_non_safe_method(self):
+        self.request.environ['REQUEST_METHOD'] = 'PUT'
+        self.render()
+
+        self.assertEqual(self.request.response.getStatus(), 412)


### PR DESCRIPTION
A poll now updates its modification date on every vote.

fixes #117