### PR TITLE
Fixed startup on Plone 6.

### DIFF
--- a/src/collective/polls/config.py
+++ b/src/collective/polls/config.py
@@ -12,4 +12,5 @@ VOTE_ANNO_KEY = 'option.%02d'
 
 PERMISSION_VOTE = 'collective.polls: Vote'
 
-IS_PLONE_5 = api.env.plone_version().startswith('5')
+# Is this Plone 5 or higher?
+IS_PLONE_5 = int(api.env.plone_version()[0]) >= 5


### PR DESCRIPTION
The Plone version detection was wrong.
The code checked for Plone 5 and then did not use zope.formlib in the portlets.
But Plone 6 was not detected, so we tried to load zope.formlib anyway. :-)

No idea if the package works on Plone 6, but this fixed initial startup. (My instance still does not startup, but now it hangs on a different package.)

I will merge this PR myself, as it is an obvious fix. PR makes it more visible than a commit.